### PR TITLE
CORS_PROXYの修正

### DIFF
--- a/src/components/news.js
+++ b/src/components/news.js
@@ -15,7 +15,7 @@ class News extends React.Component {
   }
 
   componentDidMount() {
-    const CORS_PROXY = "https://secret-ocean-49799.herokuapp.com/"
+    const CORS_PROXY = "https://floating-springs-23825.herokuapp.com/"
     let xhr = new XMLHttpRequest()
     xhr.open("GET", CORS_PROXY + "https://note.com/cocopure_nagi/rss")
     xhr.responseType = "document"


### PR DESCRIPTION
以下のプルリクでは根本的な原因の調査を大してしていない対応だった。今回は、エラーの原因を追及したので、より良いと思う修正をしました。
https://github.com/somakihiro/cocopure_nagi/pull/5

### エラーの原因

以下のissueに書いてあるように、cors-anywhereが2021/1/31でオープンプロキシではなくなった。これによってエラーが起きていた。
https://github.com/Rob--W/cors-anywhere/issues/301

### 解決策
cors-anywhereをcloneして、herokuにデプロイした。
以下のreadmeを参考にherokuの環境変数を設定し対応。
https://github.com/Rob--W/cors-anywhere#demo-server